### PR TITLE
fix: lock and greeter display correct datetime format in snipe branch

### DIFF
--- a/src/widgets/centertopwidget.h
+++ b/src/widgets/centertopwidget.h
@@ -34,6 +34,17 @@ private:
     void setTopTipText(const QString &text);
     void updateTopTipWidget();
 
+#ifdef ENABLE_DSS_SNIPE
+private slots:
+    void onUserRegionFormatValueChanged(const QDBusMessage &dbusMessage);
+
+private:
+    QString getRegionFormatConfigPath(const User *user) const;
+    QString getRegionFormatValue(const QString &userConfigDbusPath, const QString& key) const;
+    void updateRegionFormatConnection(const User *user);
+    void updateUserDateTimeFormat();
+#endif // ENABLE_DSS_SNIPE
+
 private:
     QPointer<User> m_currentUser;
     TimeWidget *m_timeWidget;

--- a/src/widgets/timewidget.cpp
+++ b/src/widgets/timewidget.cpp
@@ -80,6 +80,13 @@ void TimeWidget::refreshTime()
 
     QString date_format = shortDateFormat.at(m_shortDateIndex) + " " + weekdayFormat.at(m_weekdayIndex);
     m_dateLabel->setText(m_locale.toString(QDateTime::currentDateTime(), date_format));
+
+#ifdef ENABLE_DSS_SNIPE
+    if (!m_shortTimeFormat.isEmpty() && !m_longDateFormat.isEmpty()) {
+        m_timeLabel->setText(m_locale.toString(QTime::currentTime(), m_shortTimeFormat));
+        m_dateLabel->setText(m_locale.toString(QDate::currentDate(), m_longDateFormat));
+    }
+#endif // ENABLE_DSS_SNIPE
 }
 
 /**
@@ -122,3 +129,16 @@ QSize TimeWidget::sizeHint() const
 {
     return QSize(QWidget::sizeHint().width(), m_dateLabel->fontMetrics().height() + m_timeLabel->fontMetrics().height());
 }
+
+#ifdef ENABLE_DSS_SNIPE
+void TimeWidget::updateLocale(const QString &locale, const QString &shortTimeFormat, const QString &longDateFormat)
+{
+    m_locale = QLocale(locale);
+    if (!shortTimeFormat.isEmpty())
+        m_shortTimeFormat = shortTimeFormat;
+    if (!longDateFormat.isEmpty())
+        m_longDateFormat = longDateFormat;
+    
+    refreshTime();
+}
+#endif // ENABLE_DSS_SNIPE

--- a/src/widgets/timewidget.h
+++ b/src/widgets/timewidget.h
@@ -23,6 +23,10 @@ public:
     void updateLocale(const QLocale &locale);
     QSize sizeHint() const override;
 
+#ifdef ENABLE_DSS_SNIPE
+    void updateLocale(const QString &locale, const QString &shortTimeFormat = "", const QString &longDateFormat = "");
+#endif // ENABLE_DSS_SNIPE
+
 public Q_SLOTS:
     void setWeekdayFormatType(int type);
     void setShortDateFormat(int type);
@@ -42,6 +46,11 @@ private:
     int m_weekdayIndex = 0;
     int m_shortDateIndex = 0;
     int m_shortTimeIndex = 0;
+
+#ifdef ENABLE_DSS_SNIPE
+    QString m_shortTimeFormat;
+    QString m_longDateFormat;
+#endif // ENABLE_DSS_SNIPE
 };
 
 #endif // TIMEWIDGET_H


### PR DESCRIPTION
get user's region format config by using dConfig system dBus

Log: as title
Pms: BUG-316295