### PR TITLE
fix: greeter could not enter the password after setting a special key…

### DIFF
--- a/src/session-widgets/lockcontent.cpp
+++ b/src/session-widgets/lockcontent.cpp
@@ -112,6 +112,14 @@ void LockContent::init(SessionBaseModel *model)
     }
 
     DConfigHelper::instance()->bind(this, SHOW_MEDIA_WIDGET, &LockContent::OnDConfigPropertyChanged);
+
+    QString kbLayout = getCurrentKBLayout();
+    if (!kbLayout.isEmpty() && !kbLayout.toLower().startsWith("us")) {
+        m_originalKBLayout = kbLayout;
+        qCInfo(DDE_SHELL) << "Original keyboard layout:" << m_originalKBLayout;
+        // 如果键盘布局有特殊设置，则切换到英文键盘布局，认证成功后恢复
+        setKBLayout("us");
+    }
 }
 
 void LockContent::initUI()
@@ -184,8 +192,13 @@ void LockContent::initConnections()
     connect(m_model, &SessionBaseModel::userListChanged, this, &LockContent::onUserListChanged);
     connect(m_model, &SessionBaseModel::userListLoginedChanged, this, &LockContent::onUserListChanged);
     connect(m_model, &SessionBaseModel::authFinished, this, [this](bool successful) {
-        if (successful)
+        if (successful) {
             setVisible(false);
+            if (!m_originalKBLayout.isEmpty()) {
+                // 切换回原来的键盘布局
+                setKBLayout(m_originalKBLayout);
+            }
+        }
         restoreMode();
     });
     connect(m_model, &SessionBaseModel::MFAFlagChanged, this, [this](const bool isMFA) {
@@ -984,4 +997,27 @@ void LockContent::showShutdown()
 {
     m_model->setCurrentModeState(SessionBaseModel::ModeStatus::ShutDownMode);
     m_model->setVisible(true);
+}
+
+QString LockContent::getCurrentKBLayout() const
+{
+    QProcess p;
+    p.start("/usr/bin/setxkbmap", {"-query"});
+    p.waitForFinished();
+
+    const QString output = QString::fromUtf8(p.readAllStandardOutput());
+    for (const QString &line : output.split('\n')) {
+        if (line.startsWith("layout:")) {
+            QString layout = line.section(':', 1).trimmed();
+            return layout;
+        }
+    }
+
+    return {};
+}
+
+void LockContent::setKBLayout(const QString &layout)
+{
+    qCDebug(DDE_SHELL) << "Set keyboard layout: " << layout;
+    QProcess::execute("/usr/bin/setxkbmap", { layout});
 }

--- a/src/session-widgets/lockcontent.h
+++ b/src/session-widgets/lockcontent.h
@@ -101,6 +101,8 @@ protected:
     void initFMAWidget();
     void initUserListWidget();
     void enableSystemShortcut(const QStringList &shortcuts, bool enabled, bool isPersistent);
+    QString getCurrentKBLayout() const;
+    void setKBLayout(const QString &layout);
 
 protected:
     SessionBaseModel *m_model = nullptr;
@@ -133,6 +135,8 @@ protected:
     bool m_MPRISEnable = false;
     bool m_showMediaWidget = false;
     bool m_hasResetPasswordDialog = false;
+
+    QString m_originalKBLayout;
 };
 
 #endif // LOCKCONTENT_H


### PR DESCRIPTION
…board layout

无法输入是因为密码输入限制输入字符。而密码输入需要字母，数字，符号等，禁止其他字符，如藏文。
1.检测到设置特殊键盘布局后，修改称us键盘布局
2.认证成功后，恢复原先键盘布局。

Log: as title
Pms: BUG-317167