### PR TITLE
fix: popupWindow was hided when click network wifi item which need to…

### DIFF
--- a/src/session-widgets/lockcontent.cpp
+++ b/src/session-widgets/lockcontent.cpp
@@ -676,7 +676,7 @@ void LockContent::showModule(const QString &name, const bool callShowForce)
             qCWarning(DDE_SHELL) << "TrayButton or plugin`s content is null";
             return;
         }
-        showTrayPopup(m_currentTray, plugin->content());
+        showTrayPopup(m_currentTray, plugin->content(), callShowForce);
         break;
     }
     default:

--- a/src/session-widgets/lockcontent.h
+++ b/src/session-widgets/lockcontent.h
@@ -84,7 +84,7 @@ protected:
 
 protected:
     void toggleVirtualKB();
-    void showModule(const QString &name, const bool callShowForce = false);
+    void showModule(const QString &name, const bool callShowForce);
     void updateVirtualKBPosition();
     void onUserListChanged(QList<std::shared_ptr<User>> list);
     void tryGrabKeyboard(bool exitIfFalied = true);
@@ -92,7 +92,7 @@ protected:
     void updateWallpaper(const QString &path);
     void refreshBackground(SessionBaseModel::ModeStatus status);
     void refreshLayout(SessionBaseModel::ModeStatus status);
-    void showTrayPopup(QWidget *trayWidget, QWidget *contentWidget, const bool callShowForce = false);
+    void showTrayPopup(QWidget *trayWidget, QWidget *contentWidget, const bool callShowForce);
 
     void initUI();
     void initConnections();


### PR DESCRIPTION
… input password

clicking wifi item, network plugin call messageCallback, and send "ShowContent" message, then call toggle, popup was closed

Log: as title