### PR TITLE
fix: dde-lock can't use wlan shortcut

### DIFF
--- a/configs/org.deepin.dde.lock.json
+++ b/configs/org.deepin.dde.lock.json
@@ -53,7 +53,7 @@
             "visibility": "private"
         },
         "enableShortcutForLock":{
-            "value": ["Screenshot","Screen Recorder","Full screenshot"],
+            "value": ["Screenshot","Screen Recorder","Full screenshot","WLAN"],
             "serial": 0,
             "flags": [],
             "name": "EnableShortcutForLock",


### PR DESCRIPTION
add "WLAN" to enableShortcutForLock

Log: dde-lock can't use wlan shortcut
Bug: https://pms.uniontech.com/bug-view-275843.html Change-Id: Ide2c3ab68f787c90c3681c7973a1ed229e719901 (cherry picked from commit 1b3f216974a788e955a15975d3fc0e3c45758025)