### PR TITLE
fix: Avoid display scrollbar in the vertical direction when a single …

### DIFF
--- a/src/session-widgets/userframelist.cpp
+++ b/src/session-widgets/userframelist.cpp
@@ -45,7 +45,7 @@ UserFrameList::UserFrameList(QWidget *parent)
 
 void UserFrameList::initUI()
 {
-    m_centerWidget = new QWidget;
+    m_centerWidget = new QWidget(this);
     m_centerWidget->setAccessibleName("UserFrameListCenterWidget");
 
     m_flowLayout = new DFlowLayout(m_centerWidget);
@@ -273,6 +273,7 @@ void UserFrameList::updateLayout(int width)
     if (countWidth > 0) {
         if (m_flowLayout->count() <= count) {
             m_scrollArea->setFixedSize(countWidth, userWidgetHeight + 20);
+            m_centerWidget->setMaximumHeight(m_scrollArea->height());
         } else {
             m_scrollArea->setFixedSize(countWidth, (userWidgetHeight + UserFrameSpacing) * 2);
         }


### PR DESCRIPTION
…row of users displayed

m_centerWidget  added a maximum height constraint based on the scroll area height to improve layout management.

Log: as title
Pms: BUG-313337