### PR TITLE
feat: add camelCase conversion for key names

### DIFF
--- a/src/dde-lock/lockframe.cpp
+++ b/src/dde-lock/lockframe.cpp
@@ -171,7 +171,12 @@ bool LockFrame::event(QEvent *event)
         }
 
         if (keyValue != "") {
+#ifdef ENABLE_DSS_SNIPE
+            // v25 dde-daemon接受小驼峰命名的name
+            emit sendKeyValue(qtifyName(keyValue));
+#else
             emit sendKeyValue(keyValue);
+#endif
         }
     }
     return FullScreenBackground::event(event);

--- a/src/global_util/public_func.cpp
+++ b/src/global_util/public_func.cpp
@@ -356,3 +356,21 @@ bool isSleepLock()
     return value.toBool();
 }
 #endif
+
+QString qtifyName(const QString &name) {
+    bool next_cap = false;
+    QString result;
+    
+    for (auto it = name.cbegin(); it != name.cend(); ++it) {
+        if (*it == '-') {
+            next_cap = true;
+        } else if (next_cap) {
+            result.append(it->toUpper());
+            next_cap = false;
+        } else {
+            result.append(*it);
+        }
+    }
+    
+    return result;
+}

--- a/src/global_util/public_func.h
+++ b/src/global_util/public_func.h
@@ -82,4 +82,10 @@ void configWebEngine();
 bool isSleepLock();
 #endif
 
+/**
+ * @brief convert 'some-key' to 'someKey'.
+ */
+
+QString qtifyName(const QString &name);
+
 #endif // PUBLIC_FUNC_H


### PR DESCRIPTION
Added conditional compilation to support both original key name format and camelCase format for dde-daemon v25 compatibility Implemented qtifyName function to convert hyphenated names to camelCase by removing hyphens and capitalizing following letters Added ENABLE_DSS_SNIPE macro check to maintain backward compatibility while supporting new naming convention

feat: 为键名添加驼峰命名转换支持

添加条件编译以同时支持原始键名格式和v25 dde-daemon所需的小驼峰格式
实现qtifyName函数，通过移除连字符并大写后续字母将连字符分隔的名称转换为
驼峰命名添加ENABLE_DSS_SNIPE宏检查，在支持新命名规范的同时保持向后兼容性

pms: BUG-292567