### PR TITLE
fix: add force parameter to power actions

### DIFF
--- a/src/dde-lock/lockworker.cpp
+++ b/src/dde-lock/lockworker.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2022 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2022 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -506,7 +506,8 @@ void LockWorker::doPowerAction(const SessionBaseModel::PowerAction action)
 #else
     bool sleepLock = isSleepLock();
 #endif
-    qCInfo(DDE_SHELL) << "Do power action:" << action;
+    bool doForce = m_model->isPowerActionDoForce();
+    qCInfo(DDE_SHELL) << "Do power action:" << action << "doForce:" << doForce;
     switch (action) {
     case SessionBaseModel::PowerAction::RequireSuspend:
     {
@@ -572,7 +573,7 @@ void LockWorker::doPowerAction(const SessionBaseModel::PowerAction action)
         m_model->setShutdownMode(true);
         auto gsCheckPwd = m_model->gsCheckpwd();
         if (!isLocked() || m_model->currentModeState() == SessionBaseModel::ModeStatus::ShutDownMode || !gsCheckPwd) {
-            m_sessionManagerInter->RequestReboot();
+            doForce ? m_sessionManagerInter->ForceReboot() : m_sessionManagerInter->RequestReboot();
         } else {
             createAuthentication(m_account);
             m_model->setCurrentModeState(SessionBaseModel::ModeStatus::ConfirmPasswordMode);
@@ -591,7 +592,7 @@ void LockWorker::doPowerAction(const SessionBaseModel::PowerAction action)
         m_model->setShutdownMode(true);
         auto gsCheckPwd = m_model->gsCheckpwd();
         if (!isLocked() || m_model->currentModeState() == SessionBaseModel::ModeStatus::ShutDownMode || !gsCheckPwd) {
-            m_sessionManagerInter->RequestShutdown();
+            doForce ? m_sessionManagerInter->ForceShutdown() : m_sessionManagerInter->RequestShutdown();
         } else {
             createAuthentication(m_account);
             m_model->setCurrentModeState(SessionBaseModel::ModeStatus::ConfirmPasswordMode);
@@ -611,7 +612,7 @@ void LockWorker::doPowerAction(const SessionBaseModel::PowerAction action)
         createAuthentication(m_model->currentUser()->name());
         break;
     case SessionBaseModel::PowerAction::RequireLogout:
-        m_sessionManagerInter->RequestLogout();
+        doForce ? m_sessionManagerInter->ForceLogout() : m_sessionManagerInter->RequestLogout();
         return;
     case SessionBaseModel::PowerAction::RequireSwitchSystem:
         m_switchosInterface->setOsFlag(!m_switchosInterface->getOsFlag());

--- a/src/session-widgets/sessionbasemodel.cpp
+++ b/src/session-widgets/sessionbasemodel.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2022 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2022 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -114,14 +114,15 @@ void SessionBaseModel::setSessionKey(const QString &sessionKey)
     emit onSessionKeyChanged(sessionKey);
 }
 
-void SessionBaseModel::setPowerAction(const PowerAction &powerAction)
+void SessionBaseModel::setPowerAction(const PowerAction &powerAction, bool force)
 {
-    qCInfo(DDE_SHELL) << "Incoming action:" << powerAction << ", current action:" << m_powerAction;
+    qCInfo(DDE_SHELL) << "Incoming action:" << powerAction << ", current action:" << m_powerAction << ", force:" << force;
 
     if (powerAction == m_powerAction)
         return;
 
     m_powerAction = powerAction;
+    m_powerActionDoForce = force;
 
     if (m_enableShutdownBlackWidget && !gsCheckpwd() && (powerAction == SessionBaseModel::PowerAction::RequireRestart || powerAction == SessionBaseModel::PowerAction::RequireShutdown))
         Q_EMIT shutdownkModeChanged(true);

--- a/src/session-widgets/sessionbasemodel.h
+++ b/src/session-widgets/sessionbasemodel.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2022 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2022 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -116,7 +116,9 @@ public:
     void setSessionKey(const QString &sessionKey);
 
     inline PowerAction powerAction() const { return m_powerAction; }
-    void setPowerAction(const PowerAction &powerAction);
+    void setPowerAction(const PowerAction &powerAction, bool force = false);
+
+    bool isPowerActionDoForce() const { return m_powerActionDoForce; }
 
     ModeStatus currentModeState() const { return m_currentModeState; }
     void setCurrentModeState(const ModeStatus &currentModeState);
@@ -324,6 +326,7 @@ private:
     bool m_visibleShutdownWhenRebootOrShutdown;
     bool m_isQuickLoginProcess=false;//标志当前界面展示是否为快速登录流程
     bool m_gsCheckpwd;
+    bool m_powerActionDoForce = false; // 是否强制执行关机重启等操作
 };
 
 #endif // SESSIONBASEMODEL_H

--- a/src/widgets/warningcontent.cpp
+++ b/src/widgets/warningcontent.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2015 - 2022 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2015 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -199,7 +199,11 @@ void WarningContent::doAcceptShutdownInhibit()
         }
     }
 
+#ifndef ENABLE_DSS_SNIPE
     m_model->setPowerAction(m_powerAction);
+#else
+    m_model->setPowerAction(m_powerAction, true);
+#endif
 
     if (m_model->currentModeState() != SessionBaseModel::ModeStatus::ShutDownMode
         && m_model->currentModeState() != SessionBaseModel::ModeStatus::PowerMode


### PR DESCRIPTION
1. Modified SessionBaseModel to store force flag with power actions
2. Updated LockWorker to check force flag and call Force* methods instead of Request* methods when force is true
3. Added conditional compilation for DSS snipe mode to always use force actions
4. Enhanced logging to include force parameter in debug output

Log: Power actions (reboot/shutdown/logout) now support force execution to bypass password confirmation

fix: 为电源操作添加强制参数

1. 修改 SessionBaseModel 以存储电源操作的强制标志
2. 更新 LockWorker 以检查强制标志，当强制为真时调用 Force* 方法而不是 Request* 方法
3. 为 DSS snipe 模式添加条件编译，始终使用强制操作
4. 增强日志记录，在调试输出中包含强制参数

Log: 电源操作（重启/关机/注销）现在支持强制执行以绕过密码确认

PMS: BUG-281747