### PR TITLE
fix(auth): fix face ID text label alignment and update gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,7 @@ build*/
 *.core
 *.autosave
 *.user*
+obj-x86_64-linux-gnu/*
 
 # qm file is auto generate from .ts file
 *.qm

--- a/src/session-widgets/auth_face.cpp
+++ b/src/session-widgets/auth_face.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2021 - 2022 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2021 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -32,7 +32,8 @@ void AuthFace::initUI()
     /* 文案提示 */
     m_textLabel->setText(tr("Face ID"));
     m_textLabel->setWordWrap(true);
-    mainLayout->addWidget(m_textLabel, 1, Qt::AlignHCenter);
+    m_textLabel->setAlignment(Qt::AlignmentFlag::AlignCenter);
+    mainLayout->addWidget(m_textLabel, 1);
     /* 认证状态 */
     m_authStateLabel = new DLabel(this);
     m_authStateLabel->installEventFilter(this);


### PR DESCRIPTION
Fix Face ID text label center alignment by using AlignCenter flag instead of AlignHCenter, and add obj-x86_64-linux-gnu to gitignore.

修复Face ID文本标签居中对齐问题，使用AlignCenter替代AlignHCenter，
并将obj-x86_64-linux-gnu添加到gitignore。

Log: 修复Face ID文本标签居中对齐问题
PMS: BUG-353941
Influence: 人脸识别认证界面的文本标签显示居中对齐更加正确。