### PR TITLE
fix: adjust the title of automatic screen lock failure

### DIFF
--- a/files/snipe/dde-lock.desktop
+++ b/files/snipe/dde-lock.desktop
@@ -8,3 +8,10 @@ OnlyShowIn=DDE
 Type=Application
 X-Deepin-Vendor=user-custom
 X-Deepin-TurboType=dtkwidget
+
+Name[en_US]=Lock screen
+Name[zh_CN]=锁屏
+Name[zh_TW]=鎖定螢幕
+Name[zh_HK]=鎖定螢幕
+Name[ug]=ئېكران قۇلۇپى
+Name[bo]=བརྙན་ཡོལ་སྒོ་ལྕགས་རྒྱག་པ།

--- a/src/session-widgets/lockcontent.cpp
+++ b/src/session-widgets/lockcontent.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2022 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2022 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -836,7 +836,7 @@ void LockContent::tryGrabKeyboard(bool exitIfFailed)
             .path("/org/freedesktop/Notifications")
             .interface("org.freedesktop.Notifications")
             .method(QString("Notify"))
-            .arg(tr("Lock Screen"))
+            .arg(QString("dde-lock"))     // appName
             .arg(static_cast<uint>(0))
             .arg(QString(""))
             .arg(QString(""))


### PR DESCRIPTION
Add translation to dde-lock appName and pass in the appName in the Notify interface

dde-lock应用名添加多语言文案，并在Notify接口中传入应用名

Log: 调整自动锁屏失败的多语言文案
PMS: BUG-358777
Influence: 自动锁屏失败的通知文案是否正确