### PR TITLE
fix: adjust the title of automatic screen lock failure

### DIFF
--- a/src/session-widgets/lockcontent.cpp
+++ b/src/session-widgets/lockcontent.cpp
@@ -836,9 +836,15 @@ void LockContent::tryGrabKeyboard(bool exitIfFailed)
             .path("/org/freedesktop/Notifications")
             .interface("org.freedesktop.Notifications")
             .method(QString("Notify"))
-            .arg(QString("dde-lock"))     // appName
+#ifndef ENABLE_DSS_SNIPE
+            .arg(tr("Lock Screen"))
             .arg(static_cast<uint>(0))
             .arg(QString(""))
+#else
+            .arg(QString("dde-lock"))     // appName
+            .arg(static_cast<uint>(0))
+            .arg(QString("notification-lock-screen-failed"))
+#endif
             .arg(QString(""))
             .arg(tr("Failed to lock screen"))
             .arg(QStringList())


### PR DESCRIPTION
Add translation to dde-lock appName and pass in the appName in the Notify interface

dde-lock应用名添加多语言文案，并在Notify接口中传入应用名，区分V25版本

Log: 调整自动锁屏失败的多语言文案
PMS: BUG-358777
Influence: 自动锁屏失败的通知文案是否正确