### PR TITLE
fix(greeter): use xsettingsd.conf for scaling in snipe, fallback to e…

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -384,19 +384,15 @@ if (DISABLE_DSS_SNIPE)
     )
 endif()
 
-if (DISABLE_DSS_SNIPE)
-    add_executable(greeter-display-setting
-        src/app/greeter-display-setting.cpp
-    )
+add_executable(greeter-display-setting
+    src/app/greeter-display-setting.cpp
+)
 
-    target_link_libraries(greeter-display-setting
-        ${Qt_LIBS}
-        ${XCB_EWMH_LIBRARIES}
-        ${DtkCore_LIBRARIES}
-        ${Qt5X11Extras_LIBRARIES}
-        ${Qt5DBus_LIBRARIES}
-    )
-endif ()
+target_link_libraries(greeter-display-setting
+    ${Qt_LIBS}
+    ${XCB_EWMH_LIBRARIES}
+    Dtk${DTK_VERSION_MAJOR}::Core
+)
 
 if (DISABLE_DSS_SNIPE)
     add_subdirectory(lighter-greeter)
@@ -407,7 +403,6 @@ add_subdirectory(src/pam-inhibit-autologin)
 
 if (DISABLE_DSS_SNIPE)
     # bin
-    install(TARGETS dde-lock lightdm-deepin-greeter greeter-display-setting DESTINATION ${CMAKE_INSTALL_BINDIR})
     install(PROGRAMS files/deepin-greeter DESTINATION ${CMAKE_INSTALL_BINDIR})
 
     # install x files
@@ -425,12 +420,13 @@ if (DISABLE_DSS_SNIPE)
     install(PROGRAMS files/wayland/lightdm-deepin-greeter-wayland DESTINATION ${CMAKE_INSTALL_DATADIR}/dde-session-shell/greeters.d/wayland)
     install(FILES files/wayland/lightdm-deepin-greeter-wayland.desktop DESTINATION ${CMAKE_INSTALL_DATADIR}/xgreeters/)
 else () # snipe
-    install(TARGETS dde-lock lightdm-deepin-greeter DESTINATION ${CMAKE_INSTALL_BINDIR})
     install(PROGRAMS files/snipe/deepin-greeter DESTINATION ${CMAKE_INSTALL_BINDIR})
 
     file(GLOB SCRIPTS  files/snipe/scripts/*)
     install(PROGRAMS ${SCRIPTS} DESTINATION ${CMAKE_INSTALL_SYSCONFDIR}/deepin/greeters.d)
 endif ()
+
+install(TARGETS dde-lock lightdm-deepin-greeter greeter-display-setting DESTINATION ${CMAKE_INSTALL_BINDIR})
 
 # 指定greeter，优先级最低，允许被其他应用以更高的配置文件覆盖
 install(FILES files/50-deepin.conf DESTINATION ${CMAKE_INSTALL_DATADIR}/lightdm/lightdm.conf.d)

--- a/files/snipe/scripts/lightdm-deepin-greeter
+++ b/files/snipe/scripts/lightdm-deepin-greeter
@@ -6,6 +6,13 @@ fi
 xsettingsd_conf="/etc/lightdm/deepin/xsettingsd.conf"
 if [ -e $xsettingsd_conf ]; then
     xsettingsd -c $xsettingsd_conf &
+else
+    # xsettingsd.conf 不存在时，通过 greeter-display-setting 设置 QT 缩放环境变量
+    greeter_display_setting_path="/usr/bin/greeter-display-setting"
+    if [ -f $greeter_display_setting_path ]; then
+        scale_env=$(/usr/bin/greeter-display-setting | tail -1)
+        export $scale_env
+    fi
 fi
 
 # 判断是否有脚本需要在greeter之前调用。与更新相关功能

--- a/src/app/greeter-display-setting.cpp
+++ b/src/app/greeter-display-setting.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2015 - 2022 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2015 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 #include "constants.h"
@@ -278,7 +278,12 @@ double getScaleFormConfig()
 }
 
 static void setQtScaleFactorEnv() {
-    const double scaleFactor = IsWayland ? getScaleFormConfig() : getScaleFactor();
+    double scaleFactor = 0.0;
+#ifdef ENABLE_DSS_SNIPE
+    scaleFactor = getScaleFactor();
+#else
+    scaleFactor = IsWayland ? getScaleFormConfig() : getScaleFactor();
+#endif
     qDebug() << "Final scale factor: " << scaleFactor;
     if (scaleFactor > 0.0) {
         std::cout << QString("QT_SCALE_FACTOR="+QByteArray::number(scaleFactor)).toStdString().c_str() << std::endl;
@@ -291,9 +296,15 @@ int main(int argc, char* argv[])
 {
     // x11下，dxcb设置Qt::AA_EnableHighDpiScaling属性后，平台插件会处理缩放，不需要再主动设置QT_SCALE_FACTOR，否则会导致缩放系数相乘，得出错误的qApp->devicePixelRatio()
     // wayland下，dwayland平台插件不会处理缩放，需要手动设置QT_SCALE_FACTOR
+#ifdef ENABLE_DSS_SNIPE
+    if (!IsWayland) {
+        setQtScaleFactorEnv();
+    }
+#else
     if (IsWayland) {
         setQtScaleFactorEnv();
     }
+#endif
 
     return 0;
 }


### PR DESCRIPTION
…nv var

In the snipe branch, xsettingsd.conf is the primary way to handle display scaling. When it is absent, greeter-display-setting computes the scale factor via getScaleFactor() and exports QT_SCALE_FACTOR.

Greeter script and C++ logic are aligned: only invoke greeter-display-setting when xsettingsd.conf does not exist.

CMakeLists.txt builds greeter-display-setting for both v20 and snipe, using Dtk versioned targets instead of Qt5-specific variables.

snipe 分支优先使用 xsettingsd.conf 处理缩放，当该文件不存在时，通过
greeter-display-setting 调用 getScaleFactor() 计算缩放比并导出 QT_SCALE_FACTOR 环境变量。greeter 脚本与 C++ 逻辑保持一致，仅在
xsettingsd.conf 不存在时调用 greeter-display-setting。

CMakeLists.txt 中 greeter-display-setting 改为 snipe 和 v20 均构建。

Log: fix(greeter): use xsettingsd.conf for scaling in snipe, fallback to env var
Pms: BUG-355227
Change-Id: I7318aff3ac6966453a8b52e7766384fb1d730ec0