### PR TITLE
fix: remove glibc-based password expiry check and fix domain user

### DIFF
--- a/src/lightdm-deepin-greeter/greeterworker.cpp
+++ b/src/lightdm-deepin-greeter/greeterworker.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2022 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2022 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -556,9 +556,14 @@ void GreeterWorker::createAuthentication(const QString &account)
     if (user_ptr) {
         user_ptr->updatePasswordExpiredInfo();
     } else {
+#ifndef ENABLE_DSS_SNIPE
         // 域管账户第一次登录时，后端还未提供账户信息，获取不到用户密码过期数据
         // 需要通过glibc接口读取
         updatePasswordExpiredStateBySPName(account);
+#else
+        qCWarning(DDE_SHELL) << "createAuthentication: user not found in local model,"
+                            << "password expired info will NOT be synced. account:" << account;
+#endif
     }
 
     switch (m_model->getAuthProperty().FrameworkState) {
@@ -687,6 +692,14 @@ void GreeterWorker::checkAccount(const QString &account, bool switchUser)
             m_model->setAuthType(AT_None);
             return;
         }
+
+#ifdef ENABLE_DSS_SNIPE
+        // 新发现的用户（如域管用户首次登录），加入本地 model，
+        // 确保后续 createAuthentication 中 findUserByName 能找到
+        if (!originalUsePtr) {
+            m_model->addUser(userPath);
+        }
+#endif
     } else if (!user_ptr) {
         // 判断账户第一次登录时的有效性
         std::string str = account.toStdString();
@@ -882,10 +895,19 @@ void GreeterWorker::onAuthFinished()
     qCInfo(DDE_SHELL) << "Auth finished";
     if (m_greeter->inAuthentication()) {
         m_greeter->respond(m_authFramework->AuthSessionPath(m_account) + QString(";") + m_password);
+#ifndef ENABLE_DSS_SNIPE
         updatePasswordExpiredStateBySPName(m_account);
         if (m_model->currentUser()->expiredState() == User::ExpiredAlready) {
             changePasswd();
         }
+#else
+        if (m_model->currentUser()) {
+            m_model->currentUser()->updatePasswordExpiredInfo();
+            if (m_model->currentUser()->expiredState() == User::ExpiredAlready) {
+                changePasswd();
+            }
+        }
+#endif
     } else {
         qCWarning(DDE_SHELL) << "The lightdm is not in authentication!";
     }

--- a/src/lightdm-deepin-greeter/greeterworker.h
+++ b/src/lightdm-deepin-greeter/greeterworker.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2022 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2022 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 


### PR DESCRIPTION
handling

1. Remove `updatePasswordExpiredStateBySPName()` function that used glibc `getspnam` to check password expiry, as it was only needed for first-time domain user login
2. Ensure new domain users discovered in `checkAccount()` are added to the local model immediately, so subsequent operations like `createAuthentication()` can find them via `findUserByName()`
3. Fall back to using `updatePasswordExpiredInfo()` through existing model interfaces for all users, including newly discovered ones
4. Fix a crash in `onAuthFinished()` where `m_model->currentUser()` could be null when checking `expiredState()`

Log: Fix domain user first login; remove redundant glibc password expiry logic

Influence:
1. Test domain user first login scenario to verify password expiry info is correctly synced
2. Test normal user login to ensure no regression with password expiry checks
3. Verify no crashes occur during authentication finish for any user type
4. Test multi-user switching, including between local and domain users

fix: 移除基于 glibc 的密码过期检查并修正域管用户处理

1. 移除 `updatePasswordExpiredStateBySPName()` 函数，该函数使用 glibc 的 `getspnam` 检查密码过期，只在域管用户首次登录时需要
2. 确保在 `checkAccount()` 中新发现的域管用户立即加入本地 model，使得后 续 `createAuthentication()` 等操作能通过 `findUserByName()` 找到
3. 所有用户（包括新发现用户）都回退到通过现有 model 接口使用 `updatePasswordExpiredInfo()`
4. 修复 `onAuthFinished()` 中 `m_model->currentUser()` 可能为空时检查 `expiredState()` 导致的崩溃

Log: 修复域管用户首次登录；移除冗余的 glibc 密码过期逻辑

Influence:
1. 测试域管用户首次登录场景，验证密码过期信息是否正确同步
2. 测试普通用户登录，确保密码过期检查无回归
3. 验证任意用户在认证结束时不会发生崩溃
4. 测试多用户切换，包括本地用户和域管用户之间的切换

PMS: BUG-367143
Change-Id: Icbbe23ae6246d4e60c1dbc34d35a4f414d86e8df

## Summary by Sourcery

Align password expiry handling with the user model and remove legacy glibc-based logic.

Bug Fixes:
- Ensure newly discovered domain users are added to the local model so authentication and password expiry checks work on first login.
- Prevent a crash in authentication completion when the current user is null and password expiry state is accessed.

Enhancements:
- Rely consistently on the existing user model’s password expiry update mechanism instead of direct glibc calls.
- Log a warning when authentication is created for an account that does not yet exist in the local user model.

Chores:
- Update SPDX copyright years for the greeter worker implementation and header.