### PR TITLE
fix: clear password input undo history

### DIFF
--- a/lighter-greeter/lightergreeter.cpp
+++ b/lighter-greeter/lightergreeter.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2015 - 2023 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2015 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 #include <QApplication>
@@ -286,7 +286,7 @@ void LighterGreeter::onShowMessage(QString messageText, int messageType)
     case QLightDM::Greeter::MessageType::MessageTypeError:
         // Clear password field, set alert flag, and show error message for error messages
         if (m_passwordEdit->isVisible()) {
-            m_passwordEdit->clear();
+            m_passwordEdit->setText(QString());
             m_passwordEdit->setAlert(true);
             m_passwordEdit->showAlertMessage(messageText);
             m_passwordEdit->setFocus();
@@ -305,7 +305,7 @@ void LighterGreeter::resetToNormalGreeter()
 void LighterGreeter::updateFocus()
 {
     // Clear password field
-    m_passwordEdit->clear();
+    m_passwordEdit->setText(QString());
 
     m_passwordEdit->setVisible(true);
 

--- a/src/session-widgets/auth_password.cpp
+++ b/src/session-widgets/auth_password.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2021 - 2022 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2021 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -318,7 +318,7 @@ void AuthPassword::initConnections()
  */
 void AuthPassword::reset()
 {
-    m_lineEdit->clear();
+    m_lineEdit->setText(QString());
     m_lineEdit->setAlert(false);
     m_lineEdit->hideAlertMessage();
     setFocusProxy(m_lineEdit);
@@ -348,7 +348,7 @@ void AuthPassword::setAuthState(const AuthState state, const QString &result)
         setAnimationState(false);
         setAuthStateStyle(LOGIN_CHECK);
         m_lineEdit->setAlert(false);
-        m_lineEdit->clear();
+        m_lineEdit->setText(QString());
         setLineEditEnabled(false);
         setLineEditInfo(tr("Verification successful"), PlaceHolderText);
         m_showPrompt = true;
@@ -618,10 +618,10 @@ void AuthPassword::updateUnlockPrompt()
 {
     AuthModule::updateUnlockPrompt();
     if (m_integerMinutes == 1) {
-        m_lineEdit->clear();
+        m_lineEdit->setText(QString());
         m_lineEdit->setPlaceholderText(tr("Please try again 1 minute later"));
     } else if (m_integerMinutes > 1) {
-        m_lineEdit->clear();
+        m_lineEdit->setText(QString());
         m_lineEdit->setPlaceholderText(tr("Please try again %n minutes later", "", static_cast<int>(m_integerMinutes)));
     } else {
         setLineEditInfo(tr("Password"), PlaceHolderText);

--- a/src/session-widgets/auth_single.cpp
+++ b/src/session-widgets/auth_single.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2021 - 2022 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2021 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -137,7 +137,7 @@ void AuthSingle::initConnections()
  */
 void AuthSingle::reset()
 {
-    m_lineEdit->clear();
+    m_lineEdit->setText(QString());
     m_lineEdit->setAlert(false);
     m_lineEdit->hideAlertMessage();
     setLineEditEnabled(true);
@@ -157,14 +157,14 @@ void AuthSingle::setAuthState(const AuthCommon::AuthState state, const QString &
     case AS_Success:
         setAnimationState(false);
         m_lineEdit->setAlert(false);
-        m_lineEdit->clear();
+        m_lineEdit->setText(QString());
         setLineEditEnabled(false);
         setLineEditInfo(result, PlaceHolderText);
         emit authFinished(AS_Success);
         break;
     case AS_Failure: {
         setAnimationState(false);
-        m_lineEdit->clear();
+        m_lineEdit->setText(QString());
         if (m_limitsInfo->locked) {
             m_lineEdit->setAlert(false);
             setLineEditEnabled(false);
@@ -201,7 +201,7 @@ void AuthSingle::setAuthState(const AuthCommon::AuthState state, const QString &
         break;
     case AS_Prompt:
         setAnimationState(false);
-        m_lineEdit->clear();
+        m_lineEdit->setText(QString());
         setLineEditEnabled(true);
         setLineEditInfo(result, PlaceHolderText);
         break;

--- a/src/session-widgets/auth_ukey.cpp
+++ b/src/session-widgets/auth_ukey.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2021 - 2022 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2021 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -90,7 +90,7 @@ void AuthUKey::initConnections()
  */
 void AuthUKey::reset()
 {
-    m_lineEdit->clear();
+    m_lineEdit->setText(QString());
     m_lineEdit->setAlert(false);
     m_lineEdit->hideAlertMessage();
     setLineEditEnabled(true);
@@ -111,7 +111,7 @@ void AuthUKey::setAuthState(const AuthCommon::AuthState state, const QString &re
         setAnimationState(false);
         setAuthStateStyle(LOGIN_CHECK);
         m_lineEdit->setAlert(false);
-        m_lineEdit->clear();
+        m_lineEdit->setText(QString());
         setLineEditEnabled(false);
         setLineEditInfo(tr("Verification successful"), PlaceHolderText);
         m_showPrompt = true;
@@ -122,7 +122,7 @@ void AuthUKey::setAuthState(const AuthCommon::AuthState state, const QString &re
     case AuthCommon::AS_Failure:
         setAnimationState(false);
         setAuthStateStyle(LOGIN_WAIT);
-        m_lineEdit->clear();
+        m_lineEdit->setText(QString());
         m_lineEdit->setFocus();
         if (m_limitsInfo->locked) {
             m_lineEdit->setAlert(false);


### PR DESCRIPTION
[fix: clear password input undo history](https://github.com/linuxdeepin/dde-session-shell/pull/70/changes/58cfae8c146727a1f75832874b4b180e62af64de)
Use setText(QString()) instead of clear() when resetting password inputs so Qt clears the line edit undo history and previous passwords cannot be restored by undo after echo mode changes.

pms:TASK-392179