### PR TITLE
fix: block secure input edit shortcuts

### DIFF
--- a/lighter-greeter/lightergreeter.cpp
+++ b/lighter-greeter/lightergreeter.cpp
@@ -77,6 +77,7 @@ void LighterGreeter::initUI()
     m_userCbx->setMinimumWidth(300);
     m_passwordEdit->setMinimumWidth(300);
     m_passwordEdit->setContextMenuPolicy(Qt::NoContextMenu);
+    m_passwordEdit->setSecureInputEnabled(true);
     m_passwordEdit->lineEdit()->setAlignment(Qt::AlignCenter);
     m_passwordEdit->setClearButtonEnabled(false);
     m_passwordEdit->setEchoMode(QLineEdit::Password);

--- a/src/session-widgets/auth_password.cpp
+++ b/src/session-widgets/auth_password.cpp
@@ -93,6 +93,7 @@ void AuthPassword::initUI()
 
     m_lineEdit->setClearButtonEnabled(false);
     m_lineEdit->setEchoMode(QLineEdit::Password);
+    m_lineEdit->setSecureInputEnabled(true);
     m_lineEdit->setContextMenuPolicy(Qt::NoContextMenu);
     m_lineEdit->setFocusPolicy(Qt::StrongFocus);
     m_lineEdit->lineEdit()->setAlignment(Qt::AlignCenter);

--- a/src/session-widgets/auth_single.cpp
+++ b/src/session-widgets/auth_single.cpp
@@ -57,6 +57,7 @@ void AuthSingle::initUI()
 
     m_lineEdit->setClearButtonEnabled(false);
     m_lineEdit->setEchoMode(QLineEdit::Password);
+    m_lineEdit->setSecureInputEnabled(true);
     m_lineEdit->setContextMenuPolicy(Qt::NoContextMenu);
     m_lineEdit->setFocusPolicy(Qt::StrongFocus);
     m_lineEdit->lineEdit()->setAlignment(Qt::AlignCenter);

--- a/src/session-widgets/auth_ukey.cpp
+++ b/src/session-widgets/auth_ukey.cpp
@@ -38,6 +38,7 @@ void AuthUKey::initUI()
 
     m_lineEdit->setClearButtonEnabled(false);
     m_lineEdit->setEchoMode(QLineEdit::Password);
+    m_lineEdit->setSecureInputEnabled(true);
     m_lineEdit->setContextMenuPolicy(Qt::NoContextMenu);
     m_lineEdit->setFocusPolicy(Qt::StrongFocus);
     m_lineEdit->lineEdit()->setAlignment(Qt::AlignCenter);

--- a/src/widgets/dlineeditex.cpp
+++ b/src/widgets/dlineeditex.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2019 - 2022 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2019 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -11,6 +11,7 @@
 #include <QPropertyAnimation>
 #include <QVariantAnimation>
 #include <QKeyEvent>
+#include <QKeySequence>
 
 LoadSlider::LoadSlider(QWidget *parent)
     : QWidget(parent)
@@ -39,6 +40,7 @@ DLineEditEx::DLineEditEx(QWidget *parent)
     , m_loadSlider(new LoadSlider(this))
     , m_animation(new QPropertyAnimation(m_loadSlider, "pos", m_loadSlider))
     , m_enableTableKeyEvent(false)
+    , m_secureInputEnabled(false)
 {
     setObjectName(QStringLiteral("DLineEditEx"));
     setAccessibleName(QStringLiteral("DLineEditEx"));
@@ -128,6 +130,14 @@ void DLineEditEx::setEnableTableKeyEvent(bool enable)
     m_enableTableKeyEvent = enable;
 }
 
+void DLineEditEx::setSecureInputEnabled(bool enable)
+{
+    if (m_secureInputEnabled == enable)
+        return;
+
+    m_secureInputEnabled = enable;
+}
+
 /**
  * @brief 重写 QLineEdit paintEvent 函数，实现当文本设置居中后，holderText 仍然显示的需求
  *
@@ -170,10 +180,20 @@ bool DLineEditEx::eventFilter(QObject *watched, QEvent *event)
         && event->type() == QEvent::InputMethodQuery) {
         return true;
     } else if ((watched == this || watched == this->lineEdit())
-                && event->type() == QEvent::KeyPress
-                && m_enableTableKeyEvent) {
+               && event->type() == QEvent::KeyPress) {
         QKeyEvent *keyEvent = static_cast<QKeyEvent *>(event);
-        if (keyEvent->key() == Qt::Key_Tab
+
+        if (m_secureInputEnabled
+            && (keyEvent->matches(QKeySequence::Cut)
+                || keyEvent->matches(QKeySequence::Copy)
+                || keyEvent->matches(QKeySequence::Paste)
+                || keyEvent->matches(QKeySequence::Undo)
+                || keyEvent->matches(QKeySequence::Redo))) {
+            return true;
+        }
+
+        if (m_enableTableKeyEvent
+            && keyEvent->key() == Qt::Key_Tab
             && keyEvent->modifiers() == Qt::NoModifier
             && !this->text().isEmpty()) {
             emit this->returnPressed();

--- a/src/widgets/dlineeditex.h
+++ b/src/widgets/dlineeditex.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2019 - 2022 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2019 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -37,6 +37,7 @@ public slots:
     void startAnimation();
     void stopAnimation();
     void setEnableTableKeyEvent(bool enable);
+    void setSecureInputEnabled(bool enable);
 
 protected:
     void paintEvent(QPaintEvent *event) override;
@@ -50,6 +51,7 @@ private:
     LoadSlider *m_loadSlider;
     QPropertyAnimation *m_animation;
     bool m_enableTableKeyEvent;
+    bool m_secureInputEnabled;
 };
 
 #endif // DLINEEDITEX_H


### PR DESCRIPTION
fix: block secure input edit shortcuts

Add a secure input mode to DLineEditEx and enable it for password/PIN fields to block copy, cut, paste, undo, and redo shortcuts in one centralized path.

pms:TASK-392179

