### PR TITLE
fix(auth-password): reset password field state on reset

### DIFF
--- a/src/session-widgets/auth_password.cpp
+++ b/src/session-widgets/auth_password.cpp
@@ -323,6 +323,8 @@ void AuthPassword::reset()
     m_lineEdit->setAlert(false);
     m_lineEdit->hideAlertMessage();
     setFocusProxy(m_lineEdit);
+    m_lineEdit->setEchoMode(QLineEdit::Password);
+    m_passwordShowBtn->setIcon(QIcon(PASSWORD_SHOWN));
     hidePasswordHintWidget();
     setLineEditEnabled(true);
     setLineEditInfo(tr("Password"), PlaceHolderText);


### PR DESCRIPTION
1. Reset password input echo mode to Password on reset
2. Reset password visibility button icon to "shown" state

Log: Fix password field not resetting to obscured state and toggle button icon when reset is called

fix(auth-password): 重置时恢复密码字段状态

1. 重置时恢复密码输入框的密文显示模式
2. 重置时恢复密码可见性切换按钮的图标为"可见"状态

Log: 修复重置密码字段时未恢复密文模式和按钮图标的问题
PMS: BUG-368397

## Summary by Sourcery

Reset password field visibility state when the auth password widget is reset.

Bug Fixes:
- Ensure the password input echo mode returns to obscured (password) mode on reset.
- Ensure the password visibility toggle button icon is restored to the default "shown" state on reset.