### PR TITLE
feat: move dde-session-shell.conf to /var/lib/dde-session-shell for V25

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -455,7 +455,11 @@ else ()
 endif ()
 
 # install conf files
-install(FILES files/dde-session-shell.conf DESTINATION ${CMAKE_INSTALL_DATADIR}/dde-session-shell/)
+if (DDE_SESSION_SHELL_SNIPE)
+    install(FILES files/dde-session-shell.conf DESTINATION /var/lib/dde-session-shell/)
+else()
+    install(FILES files/dde-session-shell.conf DESTINATION ${CMAKE_INSTALL_DATADIR}/dde-session-shell/)
+endif()
 install(FILES files/lightdm-deepin-greeter.conf DESTINATION ${CMAKE_INSTALL_DATADIR}/deepin-authentication/privileges/)
 
 # services

--- a/src/global_util/constants.h
+++ b/src/global_util/constants.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2015 - 2022 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2015 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -38,7 +38,11 @@ static const int MIN_AUTH_WIDGET_HEIGHT = 276; // 密码验证时整个登录控
 const QStringList session_ui_configs {
     "/etc/lightdm/lightdm-deepin-greeter.conf",
     "/etc/deepin/dde-session-ui.conf",
+#ifdef ENABLE_DSS_SNIPE
+    "/var/lib/dde-session-shell/dde-session-shell.conf",
+#else
     "/usr/share/dde-session-shell/dde-session-shell.conf",
+#endif
     "/usr/share/dde-session-ui/dde-session-ui.conf"
 };
 

--- a/src/lightdm-deepin-greeter/logintipswindow.cpp
+++ b/src/lightdm-deepin-greeter/logintipswindow.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2011 - 2022 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2011 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -39,7 +39,7 @@ void LoginTipsWindow::initUI()
     m_content->setAlignment(Qt::AlignCenter);
     m_content->setTextFormat(Qt::TextFormat::PlainText);
 
-    // 获取/usr/share/dde-session-shell/dde-session-shell.conf 配置信息
+    // 获取 session_ui_configs 中的 dde-session-shell.conf 配置信息
     m_contentString = findValueByQSettings<QString>(DDESESSIONCC::session_ui_configs, "Greeter", "tipsContent", "");
     m_content->setText(m_contentString);
 
@@ -58,7 +58,7 @@ void LoginTipsWindow::initUI()
     m_tipLabel->setAlignment(Qt::AlignCenter);
     m_tipLabel->setTextFormat(Qt::TextFormat::PlainText);
 
-    // 获取/usr/share/dde-session-shell/dde-session-shell.conf 配置信息
+    // 获取 session_ui_configs 中的 dde-session-shell.conf 配置信息
     m_tipString = findValueByQSettings<QString>(DDESESSIONCC::session_ui_configs, "Greeter", "tipsTitle", "");
     m_tipLabel->setText(m_tipString);
 


### PR DESCRIPTION
将 dde-session-shell.conf 从 /usr/share/dde-session-shell 迁移到 /var/lib/dde-session-shell。 仅对 ENABLE_DSS_SNIPE (V25) 生效，V20 保持原有 /usr/share/dde-session-shell 路径不变。 通过条件编译区分：CMakeLists.txt 使用 if(DDE_SESSION_SHELL_SNIPE)， constants.h 使用 #ifdef ENABLE_DSS_SNIPE。

Log: 将 dde-session-shell.conf 迁移到 /var/lib/dde-session-shell (仅 V25)
PMS: BUG-356947

## Summary by Sourcery

Move dde-session-shell.conf to /var/lib/dde-session-shell when DSS snipe is enabled while keeping the existing path otherwise, and align configuration lookup comments with the new conditional paths.

Enhancements:
- Add conditional install path for dde-session-shell.conf based on DDE_SESSION_SHELL_SNIPE/ENABLE_DSS_SNIPE.
- Update session_ui_configs to use the appropriate dde-session-shell.conf location depending on build configuration.
- Clarify greeter tips window comments to reference session_ui_configs rather than a hardcoded configuration path.