### PR TITLE
fix: keep placeholder within text margins (DLineEditEx)

### DIFF
--- a/src/widgets/dlineeditex.cpp
+++ b/src/widgets/dlineeditex.cpp
@@ -160,8 +160,16 @@ void DLineEditEx::paintEvent(QPaintEvent *event)
         // 使用 elidedText 确保文本过长时在右侧显示省略号，而不是换行
         QFontMetrics fm(pa.font());
         const QString &placeholderText = lineEdit()->placeholderText();
-        QString elidedText = fm.elidedText(placeholderText, Qt::ElideRight, rect().width());
-        pa.drawText(rect(), Qt::AlignCenter | Qt::TextSingleLine, elidedText);
+        // 将 placeholder 的省略与绘制约束到扣除内嵌 QLineEdit 的 textMargins()
+        // 后的文本可用矩形内，避免长 placeholder 与左右功能图标重叠。
+        // DLineEditEx(QFrame) 与内嵌 QLineEdit 存在父子控件偏移，需用 mapTo
+        // 将 QLineEdit 坐标系映射到 DLineEditEx 绘制坐标系。
+        QLineEdit *le = lineEdit();
+        const QMargins tm = le->textMargins();
+        const QRect lineEditRect(le->mapTo(this, QPoint(0, 0)), le->size());
+        const QRect textRect = lineEditRect.adjusted(tm.left(), tm.top(), -tm.right(), -tm.bottom());
+        QString elidedText = fm.elidedText(placeholderText, Qt::ElideRight, textRect.width());
+        pa.drawText(textRect, Qt::AlignCenter | Qt::TextSingleLine, elidedText);
 
         // 当文本被省略时，设置 tooltip 显示完整文本
         if (elidedText != placeholderText) {


### PR DESCRIPTION
## 修复：锁屏/登录密码框占位符省略后与功能图标重叠

### 问题

锁屏/登录界面在「焦点态 + 空文本 + 居中 placeholder」分支手动重绘 placeholder 时，省略与绘制使用的是 `DLineEditEx` 整框 `rect()` 宽度，未扣除内嵌 `QLineEdit` 的 `textMargins()`（即大写、显示密码、认证状态、密码提示等图标的避让区），导致长错误/提示文案省略后仍横跨整框、与左右功能图标重叠。

### 改动

- 仓库：`dde-session-shell`
- 文件：`src/widgets/dlineeditex.cpp` — `DLineEditEx::paintEvent()`
- 将 placeholder 的省略（`elidedText` 宽度参数）与绘制（`drawText` 目标矩形）从整框 `rect()` 约束到「扣除内嵌 `QLineEdit` 的 `textMargins()` 后的文本可用矩形」内
- 通过 `le->mapTo(this, QPoint(0,0))` 将内嵌 `QLineEdit`（子控件）坐标映射到 `DLineEditEx`（QFrame，`QPainter(this)` 绘制坐标系），避免父子控件坐标换算导致省略宽度偏差
- tooltip 逻辑保持不变；不涉及后端 DBus / `deepin-authenticate` / DTK 控件 / DConfig / 翻译 / QSS

### 验证

- 语法/类型检查：`g++ -std=c++17 -fsyntax-only`（Qt6 / dtk6widget 头文件路径）通过，仅余一处与本次改动无关的既有 `QGuiApplication::fontChanged` 弃用告警
- 代码审核：已通过（坐标映射正确性、`textMargins` 读取时机、未设 `textMargins` 场景回归、Qt6 路径）
- 编译构建：基于 master 重建并构建通过，主包 `dde-session-shell_5.6.12.1_amd64.deb` 已产出
- 运行时 GUI 自测：英文 locale 或调大字号/缩放下、设较长密码提示、锁屏/登录输错密码后清空密码框，确认 placeholder 省略后止于左右图标内侧、不再重叠；中文短文案回归正常（待人工确认）

### 关联

- Multica issue: [DDE-67](https://agent-dev.uniontech.com/dde/issues/bc2afd6d-3542-4b07-80f6-581281c3171b)
- PMS: https://pms.uniontech.com/bug-view-351887.html (BUG-351887)

### 说明

本次 PR 仅含业务修复 `src/widgets/dlineeditex.cpp`；打包适配改动（debian/*）为本地构建所需，未纳入本 PR。PR 保持 draft/待审核状态，请勿合并。

## Summary by Sourcery

Bug Fixes:
- Ensure centered placeholders in lock/login password fields are elided and drawn within the usable text rectangle, avoiding overlap with left/right functional icons.