### PR TITLE
fix: remove wordWrap on passkey prompt label to keep single line on greeter

### DIFF
--- a/src/session-widgets/auth_passkey.cpp
+++ b/src/session-widgets/auth_passkey.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2021 - 2023 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2021 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -37,7 +37,6 @@ void AuthPasskey::initUI()
 
     /* 文案提示 */
     m_textLabel->setText(tr("Please plug in the security key"));
-    m_textLabel->setWordWrap(true);
 
     /* 旋转提示和文案提示布局 */
 #if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)


### PR DESCRIPTION
## 背景

登录界面（greeter）的安全密钥 FIDO 认证提示文案跨两行显示，而锁屏界面同样场景下一行展示正常。

关联 PMS bug：https://pms.uniontech.com/bug-view-370733.html

## 根因

greeter 在 `src/app/lightdm-deepin-greeter.cpp` 中显式把应用字体设为 **10.5pt**（为修复 bug 161915），而 `AuthPasskey` 的 `m_textLabel` 没有显式绑定字号、直接继承应用字体。`initUI()` 中 `m_textLabel->setWordWrap(true)` 与 `m_stretchLayout->addWidget(m_textLabel, 0)`（stretch 0）组合，使标签上报一个很小的 `sizeHint` 宽度，导致外层 `SFAWidget` 居中列收缩到很窄，标签被分配到约 100px 固定宽度；一旦文案自然宽度（随字号增大）超过该宽度就换行成两行。

## 改动

`src/session-widgets/auth_passkey.cpp::initUI()` 删除一行 `m_textLabel->setWordWrap(true);`，与兄弟控件 `auth_fingerprint.cpp`（不设 wordWrap、greeter/锁屏均正常单行）的写法对齐。

```diff
@@ -37,7 +37,6 @@ void AuthPasskey::initUI()

     /* 文案提示 */
     m_textLabel->setText(tr("Please plug in the security key"));
-    m_textLabel->setWordWrap(true);

     /* 旋转提示和文案提示布局 */
```

删除 wordWrap 后，标签 `sizeHint` 即文案自然宽度，打破「小 sizeHint → 外层列收缩 → 标签被挤 → 换行」的反馈链，FIDO 短提示可稳定单行展示。spinner 与两侧 `addStretch(1)` 的居中布局保持不变。

## 注意事项

- 不改动 greeter 的 10.5pt 字体设置（那是修复 bug 161915 的有意设置）。
- 仅改 dde-session-shell，未动 dde-session-shell-snipe。
- 四条提示文案（请插入安全密钥 / 正在识别安全密钥 / 验证成功 / 验证失败）均走同一个 `m_textLabel`，行为一致。

## 验证

建议在 greeter（10.5pt 字体）与锁屏两种场景下分别切到安全密钥认证界面，确认上述文案单行展示且无截断。

## Summary by Sourcery

Prevent passkey prompt labels from wrapping so security-key authentication messages remain readable on one line.

Bug Fixes:
- Keep passkey authentication prompt text on a single line in the greeter and lock-screen flows.

Chores:
- Update the copyright year in the passkey authentication widget source file.