### PR TITLE
fix(auth-passkey): remove wordWrap to keep FIDO prompt single-line

### DIFF
--- a/src/session-widgets/auth_passkey.cpp
+++ b/src/session-widgets/auth_passkey.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2021 - 2023 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2021 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -37,7 +37,6 @@ void AuthPasskey::initUI()
 
     /* 文案提示 */
     m_textLabel->setText(tr("Please plug in the security key"));
-    m_textLabel->setWordWrap(true);
 
     /* 旋转提示和文案提示布局 */
 #if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)


### PR DESCRIPTION
## 问题

登录界面（greeter）切换到 FIDO 安全密钥认证后，提示文案跨两行显示；锁屏界面同一提示文案正常单行展示。

- Multica issue: [DDE-97](https://agent-dev.uniontech.com/dde/issues/a55e3d48-3109-4e8f-a28b-f33db11885f2)
- PMS: https://pms.uniontech.com/bug-view-370733.html

## 根因

`AuthPasskey::initUI()`（`src/session-widgets/auth_passkey.cpp`）中 `m_textLabel->setWordWrap(true)` 配合文本 label `stretch=0`（嵌在带双侧 stretch 的子布局中），使 QHBoxLayout 可将 label 压缩至低于整句宽度，触发换行。

greeter 与锁屏共用同一 `AuthPasskey` 组件，但运行环境的缩放/字体不同：greeter（约 1.5x 缩放）渲染使文本宽度超过换行阈值，锁屏（1.0x）未超过。其它认证模块（`AuthFingerprint`/`AuthFace`/`AuthIris`）因不设 wordWrap 或给 label stretch=1，不受影响。

## 改动

删除 `AuthPasskey::initUI()` 中 `m_textLabel->setWordWrap(true);` 一行，与 `AuthFingerprint` 保持一致。

```diff
     /* 文案提示 */
     m_textLabel->setText(tr("Please plug in the security key"));
-    m_textLabel->setWordWrap(true);

     /* 旋转提示和文案提示布局 */
```

移除 wordWrap 后，QLabel 的 `minimumSizeHint() == sizeHint()`（完整单行宽度），QHBoxLayout 无法再压缩该 label，两侧 stretch 自动让出空间，文案结构性保证单行展示——对 greeter 与锁屏均生效，锁屏无回归（由"碰巧不换行"变为"结构上不可换行"）。

## 验证

- 代码审核：通过（98 分）
- 编译打包：Qt6 编译通过，deb 包已构建（dde-session-shell 6.0.66）
- 未改动 greeter 字体设置（bug 161915 相关）及其它认证模块

## 说明

- GitHub `master` 分支为 v20/Qt5 变体，系统实际运行的 6.0.x 为 Qt6/snipe 变体，两者 `auth_passkey.cpp` 经验证完全一致（唯一差异即本次删除行），故直接在 master 分支提交。
- 本 PR 为 draft，待人工审核合并。

## Summary by Sourcery

Keep passkey authentication prompts on a single line across authentication environments.

Bug Fixes:
- Prevent FIDO security-key authentication prompts from wrapping onto multiple lines in the greeter and lock screen.

Chores:
- Update the auth-passkey source copyright year range.